### PR TITLE
Rename the Support page to Contact Us

### DIFF
--- a/docs/api/contact_us.md
+++ b/docs/api/contact_us.md
@@ -1,0 +1,16 @@
+---
+layout: default
+title: Contact Us
+nav: contact_us
+
+---
+### Support
+
+To receive support or ask questions about , post an issue in our [GitHub issues](https://github.com/GSA/GSA-APIs/issues).
+
+Be sure to check out our [Frequently Asked Questions page]("FAQ.html), which may answer your questions.
+
+### Alternate Contact
+If you are unable to post an an issue in GitHub, email us at [example@gsa.gov](example@gsa.gov).
+
+<body id="getting_support"></body>


### PR DESCRIPTION
The contact page can refer them for support and other types of contact.